### PR TITLE
PR - Updated import paths

### DIFF
--- a/src/common/evaluation/batch_evaluation.py
+++ b/src/common/evaluation/batch_evaluation.py
@@ -4,7 +4,7 @@ Handles multi-turn conversations and surfaces diagnostics, including parameter a
 """
 from __future__ import annotations
 import builtins
-from langchain.schema import BaseMessage
+from langchain_core.messages import BaseMessage
 import operator
 from typing import Dict, List, Annotated, Sequence, Optional
 builtins.Annotated = Annotated

--- a/src/frameworks/autogen_agents/autogen_mcp_client.py
+++ b/src/frameworks/autogen_agents/autogen_mcp_client.py
@@ -14,7 +14,7 @@ Example: Autogen agent that uses MCP tools (math and weather).
 import asyncio
 from typing import List
 
-from langchain.tools import Tool
+from langchain_core.tools import tool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
 from openai_autogen import (

--- a/src/frameworks/langgraph_agents/ecommerce_customer_support/customer_support_agent.py
+++ b/src/frameworks/langgraph_agents/ecommerce_customer_support/customer_support_agent.py
@@ -7,16 +7,19 @@ using LangGraph's built-in tool-calling via @tool decorators.
 import os
 import json
 import operator
-import builtins
 from typing import Annotated, Sequence, TypedDict, Optional
 
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
-from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import (
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
-from langgraph.graph import StateGraph, END
+from langchain_core.tools import tool
+from langgraph.graph import StateGraph
 
 from traceloop.sdk import Traceloop
 from src.common.observability.loki_logger import log_to_loki

--- a/src/frameworks/langgraph_agents/ecommerce_customer_support/customer_support_agent_with_traceloop.py
+++ b/src/frameworks/langgraph_agents/ecommerce_customer_support/customer_support_agent_with_traceloop.py
@@ -9,12 +9,16 @@ import operator
 import builtins
 from typing import Annotated, Sequence, TypedDict
 
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
-from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import (
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
+from langchain_core.tools import tool
 from langgraph.graph import StateGraph, END
 
 from traceloop.sdk import Traceloop

--- a/src/frameworks/langgraph_agents/financial_services/financial_services_agent.py
+++ b/src/frameworks/langgraph_agents/financial_services/financial_services_agent.py
@@ -10,13 +10,17 @@ import operator
 import builtins
 from typing import Annotated, Sequence, TypedDict, Optional
 
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
-from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import (
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
-from langgraph.graph import StateGraph, END
+from langchain_core.tools import tool
+from langgraph.graph import StateGraph
 
 from traceloop.sdk import Traceloop
 from src.common.observability.loki_logger import log_to_loki

--- a/src/frameworks/langgraph_agents/healthcare/healthcare_patient_intake_agent.py
+++ b/src/frameworks/langgraph_agents/healthcare/healthcare_patient_intake_agent.py
@@ -10,13 +10,17 @@ import operator
 import builtins
 from typing import Annotated, Sequence, TypedDict, Optional
 
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
-from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import (
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
-from langgraph.graph import StateGraph, END
+from langchain_core.tools import tool
+from langgraph.graph import StateGraph
 
 from traceloop.sdk import Traceloop
 from src.common.observability.loki_logger import log_to_loki

--- a/src/frameworks/langgraph_agents/it_helpdesk/it_helpdesk_agent.py
+++ b/src/frameworks/langgraph_agents/it_helpdesk/it_helpdesk_agent.py
@@ -10,12 +10,12 @@ import operator
 import builtins
 from typing import Annotated, Sequence, TypedDict, Optional
 
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
+from langchain_core.tools import tool
 from langgraph.graph import StateGraph, END
 
 from traceloop.sdk import Traceloop

--- a/src/frameworks/langgraph_agents/langgraph_mcp_client.py
+++ b/src/frameworks/langgraph_agents/langgraph_mcp_client.py
@@ -2,8 +2,8 @@ import asyncio
 import json
 import os
 
-from langchain.schema import HumanMessage
-from langchain.tools import Tool
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
 from langgraph.graph import StateGraph, END

--- a/src/frameworks/langgraph_agents/legal/legal_document_review_agent.py
+++ b/src/frameworks/langgraph_agents/legal/legal_document_review_agent.py
@@ -10,12 +10,12 @@ import operator
 import builtins
 from typing import Annotated, Sequence, TypedDict, Optional
 
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
+from langchain_core.tools import tool
 from langgraph.graph import StateGraph, END
 
 from traceloop.sdk import Traceloop

--- a/src/frameworks/langgraph_agents/soc/soc_analyst_agent.py
+++ b/src/frameworks/langgraph_agents/soc/soc_analyst_agent.py
@@ -10,12 +10,12 @@ import operator
 import builtins
 from typing import Annotated, Sequence, TypedDict, Optional
 
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
+from langchain_core.tools import tool
 from langgraph.graph import StateGraph, END
 
 from traceloop.sdk import Traceloop

--- a/src/frameworks/langgraph_agents/supply_chain/ray_supply_chain_multi_agent.py
+++ b/src/frameworks/langgraph_agents/supply_chain/ray_supply_chain_multi_agent.py
@@ -13,12 +13,12 @@ import time
 from typing import Annotated, Sequence, TypedDict, Optional, Dict
 
 import ray
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
+from langchain_core.tools import tool
 from langgraph.graph import StateGraph, END
 
 from traceloop.sdk import Traceloop

--- a/src/frameworks/langgraph_agents/supply_chain/redis_streams_multi_agent_supply_chain.py
+++ b/src/frameworks/langgraph_agents/supply_chain/redis_streams_multi_agent_supply_chain.py
@@ -14,12 +14,12 @@ from typing import Annotated, Sequence, TypedDict, Optional
 import multiprocessing
 
 import redis
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
+from langchain_core.tools import tool
 from langgraph.graph import StateGraph, END
 
 from traceloop.sdk import Traceloop

--- a/src/frameworks/langgraph_agents/supply_chain/supply_chain_logistics_agent.py
+++ b/src/frameworks/langgraph_agents/supply_chain/supply_chain_logistics_agent.py
@@ -10,12 +10,12 @@ import operator
 import builtins
 from typing import Annotated, Sequence, TypedDict, Optional
 
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
+from langchain_core.tools import tool
 from langgraph.graph import StateGraph, END
 
 from traceloop.sdk import Traceloop

--- a/src/frameworks/langgraph_agents/supply_chain/supply_chain_logistics_multi_agent.py
+++ b/src/frameworks/langgraph_agents/supply_chain/supply_chain_logistics_multi_agent.py
@@ -9,12 +9,12 @@ import json
 import operator
 from typing import Annotated, Sequence, TypedDict, Optional
 
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
+from langchain_core.tools import tool
 from langgraph.graph import StateGraph, END
 
 from traceloop.sdk import Traceloop

--- a/src/frameworks/langgraph_agents/supply_chain/temporal_supply_chain_multi_agent.py
+++ b/src/frameworks/langgraph_agents/supply_chain/temporal_supply_chain_multi_agent.py
@@ -14,12 +14,12 @@ from typing import Annotated, Sequence, TypedDict, Optional, Dict, Any
 from temporalio import workflow, activity
 from temporalio.common import RetryPolicy
 
-from langchain_openai.chat_models import ChatOpenAI
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.messages.tool import ToolMessage
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from langchain.tools import tool
+from langchain_core.tools import tool
 from temporalio.client import Client
 from temporalio.worker import Worker
 

--- a/tests/frameworks/langgraph_agents/test_langgraph_customer_support_agent.py
+++ b/tests/frameworks/langgraph_agents/test_langgraph_customer_support_agent.py
@@ -1,5 +1,5 @@
 import pytest
-from langchain.schema import HumanMessage
+from langchain_core.messages import HumanMessage
 from frameworks.langgraph_agents.ecommerce_customer_support.customer_support_agent import graph
 
 def extract_tool_names(messages):


### PR DESCRIPTION
Updated import paths to match the current LangChain and Traceloop module structure. Replaced deprecated/removed imports with their correct equivalents to restore compatibility with the latest library versions.

Import Path Changes
-------------------

1) StreamingStdOutCallbackHandler:
   from:  from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
   to:    from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler

2) @tool decorator:
   from:  from langchain.tools import tool
   to:    from langchain_core.tools import tool

3) ChatOpenAI:
   from:  from langchain_openai.chat_models import ChatOpenAI
   to:    from langchain_openai import ChatOpenAI

4) Message classes:
   from:  from langchain.schema import HumanMessage, AIMessage, SystemMessage
   to:    from langchain_core.messages import HumanMessage, AIMessage, SystemMessage